### PR TITLE
Removing itemActivated handler, incorrectly used in Contextual Popup, wa...

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -59,7 +59,6 @@ enyo.kind({
 		onTap: ""
 	},
 	handlers: {
-		onActivate: "itemActivated",
 		onRequestShowPopup: "requestShow",
 		onRequestHidePopup: "requestHide"
 	},
@@ -106,10 +105,6 @@ enyo.kind({
 	},
 	maxHeightChanged: function() {
 	    this.scrolling ? this.getScroller().setMaxHeight(this.maxHeight + "px") : enyo.nop;	
-	},
-	itemActivated: function(inSender, inEvent) {
-		inEvent.originator.setActive(false);		
-		return true;
 	},
 	showingChanged: function() {
 		this.inherited(arguments);


### PR DESCRIPTION
...s meant only for Menus & Pickers.

Needed to fix this for Mochi too (just in case).

Enyo-DCO-1.1-Signed-off-by: Steven Feaster steven.feaster@palm.com
