### PR TITLE
ENYO-4057: Update samples to use "renderInto" instead of "write".

### DIFF
--- a/samples/BadgeSample.html
+++ b/samples/BadgeSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.BadgeSample({classes: "enyo-unselectable"}).write();
+	new mochi.sample.BadgeSample({classes: "enyo-unselectable"}).renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/ButtonSample.html
+++ b/samples/ButtonSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.ButtonSample({classes: "enyo-unselectable"}).write();
+	new mochi.sample.ButtonSample({classes: "enyo-unselectable"}).renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/CheckboxSample.html
+++ b/samples/CheckboxSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.CheckboxSample({classes: "enyo-unselectable"}).write();
+	new mochi.sample.CheckboxSample({classes: "enyo-unselectable"}).renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/ContextualPopupSample.html
+++ b/samples/ContextualPopupSample.html
@@ -18,7 +18,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.ContextualPopupSample({fit: true, classes: "enyo-unselectable"}).write();
+	new mochi.sample.ContextualPopupSample({fit: true, classes: "enyo-unselectable"}).renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/GridListSample.html
+++ b/samples/GridListSample.html
@@ -16,7 +16,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.GridListSample({fit: true}).write();
+	new mochi.sample.GridListSample({fit: true}).renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/HeaderSample.html
+++ b/samples/HeaderSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.HeaderSample({classes: "enyo-unselectable"}).write();
+	new mochi.sample.HeaderSample({classes: "enyo-unselectable"}).renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/IconButtonSample.html
+++ b/samples/IconButtonSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.IconButtonSample({classes: "enyo-unselectable"}).write();
+	new mochi.sample.IconButtonSample({classes: "enyo-unselectable"}).renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/InputSample.html
+++ b/samples/InputSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.InputSample({classes: "enyo-unselectable"}).write();
+	new mochi.sample.InputSample({classes: "enyo-unselectable"}).renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/ListSample.html
+++ b/samples/ListSample.html
@@ -16,7 +16,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.ListSample({classes: "enyo-unselectable"}).write();
+	new mochi.sample.ListSample({classes: "enyo-unselectable"}).renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/PanelsSample.html
+++ b/samples/PanelsSample.html
@@ -18,7 +18,7 @@
 </head>
 <body class="enyo-unselectable">
 		<script>
-			new mochi.sample.PanelsSample().write();
+			new mochi.sample.PanelsSample().renderInto(document.body);
 		</script>
 	</body>
 </html>

--- a/samples/ProgressSample.html
+++ b/samples/ProgressSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.ProgressSample({classes: "enyo-unselectable"}).write();
+	new mochi.sample.ProgressSample({classes: "enyo-unselectable"}).renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/RadioButtonSample.html
+++ b/samples/RadioButtonSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.RadioButtonSample().write();
+	new mochi.sample.RadioButtonSample().renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/SliderSample.html
+++ b/samples/SliderSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.SliderSample().write();
+	new mochi.sample.SliderSample().renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/SpinnerSample.html
+++ b/samples/SpinnerSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.SpinnerSample().write();
+	new mochi.sample.SpinnerSample().renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/ToggleButtonSample.html
+++ b/samples/ToggleButtonSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.ToggleButtonSample().write();
+	new mochi.sample.ToggleButtonSample().renderInto(document.body);
 </script>
 </body>
 </html>

--- a/samples/ViewSelectButtonSample.html
+++ b/samples/ViewSelectButtonSample.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <script type="text/javascript">
-	new mochi.sample.ViewSelectButtonSample().write();
+	new mochi.sample.ViewSelectButtonSample().renderInto(document.body);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Issue

Enyo 2.5.0+ deprecates the `write` method, so the samples do not load.
## Fix

Use the more standard `renderInto` method when loading samples.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
